### PR TITLE
update KeyStoreType.java, load as PKCS#12 first

### DIFF
--- a/src/main/net/sf/portecle/crypto/KeyStoreType.java
+++ b/src/main/net/sf/portecle/crypto/KeyStoreType.java
@@ -35,10 +35,10 @@ import java.util.Set;
  */
 public enum KeyStoreType
 {
+	/** PKCS #12 keystore Type */
+	PKCS12(null, "PKCS #12", false, false, new String[] { "p12", "pfx" }),	
 	/** JKS keystore Type */
 	JKS(null, "JKS", true, true, new String[] { "jks" }),
-	/** PKCS #12 keystore Type */
-	PKCS12(null, "PKCS #12", false, false, new String[] { "p12", "pfx" }),
 	/** JCEKS keystore Type */
 	JCEKS(null, "JCEKS", true, true, new String[] { "jceks" }),
 	/** Case sensitive JKS keystore Type */


### PR DESCRIPTION
bugfix for PKCS#12 loading as JKS keystore type. 

FPortecle.openKeyStoreFile() tries to load a keystore as a keystore of a given type until it succeeds without exceptions or null store.
Java 8+ succeeds in loading PKCS#12 stores as JKS but lacks all features a PKCS#12 store needs.
Trying to load as a PKCS#12 type first avoid this problem.
FPortecle.openKeyStoreFile() uses the order given in this KeyStoreType enum.